### PR TITLE
Added a note to Translation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All languages have a different word order and cutural background. Therefore, we 
      - Homepage: https://status.im/
      - Repo: https://github.com/status-im/status.im
    - Notes:
+     - For Status Dapp translations: keep these as short as possible, don't add nouns or verbs unless absolutely necessary. The translation is shown on Mobile; space is limited.
      - Please don't translate `Empty` in the project It should be a blank.
      - Check out the `unverified` translation first. It means some outdated translations need your updates.
        <img src="https://lh3.googleusercontent.com/OPU1M51hYIH9GrQ_RJHi6S9cqvsqD4os_S8Lez2qDAbgz0tj4xoVUZaq0yqsrTKlljw4LScFaeLM_2eYYqtE53BregumcxuMoifswcVDlm51YBwiiOS80Kfaj3UPP5SZbABqjRV9=w2400" width="300">


### PR DESCRIPTION
Added:
>    For Status Dapp translations: keep these as short as possible, don't add nouns or verbs unless absolutely necessary. The translation is shown on Mobile; space is limited.